### PR TITLE
Add Accredible-Integration header to create credential

### DIFF
--- a/vendor/accredible/acms-api-php/src/Api.php
+++ b/vendor/accredible/acms-api-php/src/Api.php
@@ -121,7 +121,10 @@ class Api {
 
 		$client = new \GuzzleHttp\Client();
 
-		$params = array('Authorization' => 'Token token="'.$this->getAPIKey().'"');
+		$params = array(
+			'Authorization' => 'Token token="'.$this->getAPIKey().'"',
+			'Accredible-Integration' => 'Wordpress'
+		);
 
 		$response = $client->post($this->api_endpoint.'credentials', array(
 		    'headers' => $params,
@@ -163,7 +166,10 @@ class Api {
 
         $client = new \GuzzleHttp\Client();
 
-        $params = array('Authorization' => 'Token token="'.$this->getAPIKey().'"');
+        $params = array(
+			'Authorization' => 'Token token="'.$this->getAPIKey().'"',
+			'Accredible-Integration' => 'Wordpress'
+		);
 
         $response = $client->post($this->api_endpoint.'credentials', array(
             'headers' => $params,


### PR DESCRIPTION
Added a `Accredible-Integration` header to the `POST /v1/credentials` calls.

Manually tested if it works as expected with a local WordPress and an Accredible account in the production.