### PR TITLE
lowercase emails before comparing with credential email

### DIFF
--- a/accredible-academy-theme.php
+++ b/accredible-academy-theme.php
@@ -161,7 +161,7 @@ if(!class_exists('Accredible_Acadmey_Theme'))
 
 				$issue = true;
 				foreach ($existing_certificates as $key => $certificate) {
-					if($certificate->recipient->email == $user->user_email){
+					if($certificate->recipient->email == strtolower( $user->user_email )){
 						$issue = false;
 					}
 				}

--- a/accredible_certificates.php
+++ b/accredible_certificates.php
@@ -288,7 +288,8 @@ if(!class_exists('Accredible_Certificate'))
           $cert_exit = False;
           if(is_array($all_certificates)){
 			foreach ($all_certificates as $key => $cert) {
-			  if($cert->recipient->email == $user->user_email){
+			  $user_email = strtolower( $user->user_email );
+			  if($cert->recipient->email == $user_email){
 			    $cert_exit = True;
 			    $cert_id = $cert->id;
 			    $approve = $cert->approve;

--- a/users_list.php
+++ b/users_list.php
@@ -89,7 +89,7 @@ class Users_List extends WP_List_Table {
         	// batch request to get user credentials
 			$requests = [];
 	        for ($x=0; $x < count($result); $x++) { 
-	        	array_push($requests, ["method" => "get", "url" => "all_credentials", "params" => ["email" =>  $result[$x]["user_email"]] ]);
+	        	array_push($requests, ["method" => "get", "url" => "all_credentials", "params" => ["email" =>  strtolower( $result[$x]["user_email"] )] ]);
 	        }
 
         	try {

--- a/vendor/accredible/acms-api-php/src/Api.php
+++ b/vendor/accredible/acms-api-php/src/Api.php
@@ -85,6 +85,9 @@ class Api {
 	 */
 	public function get_credentials($group_id = null, $email = null, $page_size = null, $page = 1){
 		$client = new \GuzzleHttp\Client();
+        if ($email) {
+            $email = strtolower($email);
+        }
 
 		$params = array('headers' =>  array('Authorization' => 'Token token="'.$this->getAPIKey().'"'));
 


### PR DESCRIPTION
The emails from the credentials are always in lowercase.

This PR ensure that all emails are lowercase when comparing to fix an issue
where users with uppercase emails can't find their credential.